### PR TITLE
refactor: minimum tracks to qualify an album as such

### DIFF
--- a/src/main/java/org/hihn/ampd/server/model/AmpdSettings.java
+++ b/src/main/java/org/hihn/ampd/server/model/AmpdSettings.java
@@ -105,6 +105,12 @@ public class AmpdSettings {
 	@Value("${application.version}")
 	private String version;
 
+    /**
+	 * Least amount of tracks that an album must have to be considered such
+	 */
+	@Value("${albums.qualify.min.tracks}")
+	private int albumsQualifyMinTracks;
+
 	/**
 	 * Page size for the album cover browse view.
 	 */
@@ -234,6 +240,10 @@ public class AmpdSettings {
 	public String getCoverNamePattern() {
 		return coverNamePattern;
 	}
+
+    public int getAlbumsQualifyMinTracks() {
+        return albumsQualifyMinTracks;
+    }
 
 	public String getVersion() {
 		return version;

--- a/src/main/java/org/hihn/ampd/server/service/AlbumService.java
+++ b/src/main/java/org/hihn/ampd/server/service/AlbumService.java
@@ -78,10 +78,7 @@ public class AlbumService {
 
 			try {
 				int albumContains = mpd.getMusicDatabase().getSongDatabase().findAlbum(album).size();
-				if (albumContains < 2) {
-					// Some tracks have the album attribute set but are not actually
-					// part of an album but a singleton. Only use albums with at least
-					// 2 tracks
+				if (albumContains < ampdSettings.getAlbumsQualifyMinTracks()) {
 					return false;
 				}
 			}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -33,6 +33,8 @@ publisher.delay=250
 min.score=75
 # Artwork finder: filename pattern for glob
 artwork.filename.pattern=**.{jpg,jpeg,png}
+# Least amount of tracks that an album must have to be considered such
+albums.qualify.min.tracks=2
 # Page size for browsing albums
 albums.page.size=32
 # Page size for search results


### PR DESCRIPTION
Greetings. I noticed that you had a magic number for the amount of tracks that define an album as such (e.g. to avoid singles), I felt this would be fit as an application-level setting as I would have set it to 3 instead of 2, as I have several two-sided singles in my collection hehe.

Let me know if I can do anything else to get this merged :)